### PR TITLE
'extracted' is the correct name not 'features'

### DIFF
--- a/bob/bio/base/tools/scoring.py
+++ b/bob/bio/base/tools/scoring.py
@@ -160,7 +160,7 @@ def _scores_c(algorithm, t_model_ids, group, force):
 
   # probe files:
   probe_objects = fs.probe_objects(group)
-  probe_files = fs.get_paths(probe_objects, 'projected' if algorithm.performs_projection else 'features')
+  probe_files = fs.get_paths(probe_objects, 'projected' if algorithm.performs_projection else 'extracted')
 
   logger.info("- Scoring: computing score matrix C for group '%s'", group)
 
@@ -182,7 +182,7 @@ def _scores_d(algorithm, t_model_ids, group, force):
 
   # probe files:
   z_probe_objects = fs.z_probe_objects(group)
-  z_probe_files = fs.get_paths(z_probe_objects, 'projected' if algorithm.performs_projection else 'features')
+  z_probe_files = fs.get_paths(z_probe_objects, 'projected' if algorithm.performs_projection else 'extracted')
 
   logger.info("- Scoring: computing score matrix D for group '%s'", group)
 


### PR DESCRIPTION
The error I was getting while using the bob.bio.base verify.py script before
this commit. My invoke command was:

```
'bob.example.facevoice/bin/verify.py' -vv --grid 'grid' --preprocessor 'inorm-lbp-cro p' --extractor 'grid-graph' --algorithm 'gabor-jet' -d 'mobio-male' --zt-norm --groups 'eval' --sub-directory 'baselines/gabor-graph' --sub-task 'compute-scores' --group 'eval' --score-type 'C'
```

the error:

```python
bob.bio.base@2016-03-09 14:36:22,159 -- ERROR: During the execution, an exception was raised: The given directory type 'features' is not supported.
Traceback (most recent call last):
  File "/home/miniconda2/envs/bob.example.facevoice/bin/verify.py", line 6, in <module>
    sys.exit(bob.bio.base.script.verify.main())
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/script/verify.py", line 435, in main
    verify(args, command_line_parameters)
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/script/verify.py", line 382, in verify
    if not execute(args):
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/script/verify.py", line 338, in execute
    write_compressed = args.write_compressed_score_files)
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/tools/scoring.py", line 273, in compute_scores
    _scores_c(algorithm, t_model_ids, group, force)
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/tools/scoring.py", line 163, in _scores_c
    probe_files = fs.get_paths(probe_objects, 'projected' if algorithm.performs_projection else 'features')
  File "/home/miniconda2/envs/bob.example.facevoice/lib/python2.7/site-packages/bob.bio.base-2.0.5-py2.7.egg/bob/bio/base/tools/FileSelector.py", line 103, in get_paths
    raise ValueError("The given directory type '%s' is not supported." % directory_type)
ValueError: The given directory type 'features' is not supported.
```

`jman list` output:

```
$ jman list
 job-id         grid-id             queue           status            job-name                   submitted command line          
========  ====================  ==============  ==============  ====================  ===========================================
   1        533393 [1-32:1]         all.q        success (0)         enr-N-eval       '/home..
   2        533394 [1-32:1]         all.q        success (0)         enr-T-eval       '/home..
   3        533395 [1-32:1]         all.q        success (0)        score-A-eval      '/home..
   4        533396 [1-32:1]         all.q        success (0)        score-B-eval      '/home..
   5        533397 [1-32:1]         all.q        failure (1)        score-C-eval      '/home..
   6        533398 [1-32:1]         all.q        failure (1)        score-D-eval      '/home..
   7             533399           extatix08      failure (1)        score-Z-eval      '/home..
   8             533400           extatix08      failure (1)        concat-eval       '/home..
```